### PR TITLE
Update package to use with mpl3.9.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ project_urls =
 [options]
 packages = sphinx_rtd_light_dark
 setup_requires = setuptools>=44; toml; setuptools_scm>=3.4.3
-install_requires = pygments; sphinx_rtd_theme==0.4.3
+install_requires = pygments; sphinx_rtd_theme>=2.0.0
 include_package_data = True
 python_requires = >=3.6.0
 

--- a/sphinx_rtd_light_dark/layout.html
+++ b/sphinx_rtd_light_dark/layout.html
@@ -14,11 +14,11 @@
     css_files method does *not require* pathto() but do not understand why
 -->
 {% block extrahead %}
-  <link rel="stylesheet" href="{{ pathto("_static/pygments/default.css", True) }}" type="text/css" id="pygments-style">
-  <link rel="stylesheet" href="{{ pathto("_static/light-dark.css", True) }}" type="text/css">
+  <link rel="stylesheet" href="{{ pathto('_static/pygments/default.css', True) }}" type="text/css" id="pygments-style">
+  <link rel="stylesheet" href="{{ pathto('_static/light-dark.css', True) }}" type="text/css">
   {{ super() }}
 {% endblock %}
 {% block document %}
-  <script type="text/javascript" src={{ pathto("_static/light-dark.js", True) }}></script>
+  <script type="text/javascript" src="{{ pathto('_static/light-dark.js', True) }}"></script>
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
Sphinx got up dated causing an issue with the removal of a keyword in sphinx. This is necessary for building with the latest mpl. See https://github.com/proplot-dev/proplot/pull/459